### PR TITLE
Fix imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ We recommend using conda and creating a new conda environment such as:
 
 ::
 
-   conda create -n py_array python=3 obspy
+   conda create -n py_array -c conda-forge python=3 obspy
 
 Information on conda environments (and more) is available
 `here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__.

--- a/lts_array/flts_helper_array.py
+++ b/lts_array/flts_helper_array.py
@@ -6,8 +6,6 @@ from scipy.linalg import lstsq
 from copy import deepcopy
 from obspy.geodetics.base import calc_vincenty_inverse
 
-import lts_array.flts_helper_array as fltsh
-
 """ Contains the auxilliary functions called by fast_lts_array.py
 
 Many of these codes are Python3 translations of those found in
@@ -78,11 +76,11 @@ def randomset(tot, npar, seed):
 
     randlist = []
     for jj in range(0, npar):
-        random, seed = fltsh.uniran(seed)
+        random, seed = uniran(seed)
         num = np.floor(random * tot) + 1
         if jj > 0:
             while num in randlist:
-                random, seed = fltsh.uniran(seed)
+                random, seed = uniran(seed)
                 num = np.floor(random * tot) + 1
         randlist.append(num)
 
@@ -98,7 +96,7 @@ def qgamma(p, a):
     dx = 1
     eps = 7/3 - 4/3 - 1
     while np.abs(dx) > 256 * eps * np.max(np.append(x, 1)):
-        dx = (fltsh.pgamma(x, a) - p) / fltsh.dgamma(x, a)
+        dx = (pgamma(x, a) - p) / dgamma(x, a)
         x = x - dx
         x = x + (dx - x) / 2 * float(x < 0)
 
@@ -123,7 +121,7 @@ def dgamma(x, a):
 
 def qchisq(p, a):
     """ The Chi-squared inverse distribution function. """
-    x = 2*fltsh.qgamma(p, 0.5*a)
+    x = 2*qgamma(p, 0.5*a)
     return x
 
 
@@ -410,13 +408,13 @@ def rewconsfactorlts(weights, n, p):
         cdelta_rew = 1
     else:
         if p == 0:
-            qdelta_rew = fltsh.qchisq(np.sum(weights)/n, 1)
-            cdeltainvers_rew = fltsh.pgamma(
+            qdelta_rew = qchisq(np.sum(weights)/n, 1)
+            cdeltainvers_rew = pgamma(
                 qdelta_rew/2, 1.5) / (np.sum(weights) / n)
             cdelta_rew = np.sqrt(1/cdeltainvers_rew)
         else:
-            a = fltsh.dnorm(1/(1/(fltsh.qnorm((sum(weights)+n)/(2*n)))))
-            b = (1/fltsh.qnorm((np.sum(weights)+n)/(2*n)))
+            a = dnorm(1/(1/(qnorm((sum(weights)+n)/(2*n)))))
+            b = (1/qnorm((np.sum(weights)+n)/(2*n)))
             q = 1-((2*n)/(np.sum(weights)*b))*a
             cdelta_rew = 1/np.sqrt(q)
 


### PR DESCRIPTION
This PR fixes https://github.com/uafgeotools/lts_array/issues/10 by removing some circular imports in `flts_helper_array.py`. Since the functions are defined in the file itself there is no need to import them. I'm not sure why things worked in Python 3.7 + 3.8, maybe the import rules changed.

I also added `-c conda-forge` to make sure conda finds Obspy.

Pinging @davidfee5 and @jwbishop.