### PR TITLE
Allow users to directly pass an `rij` array to `ltsva()`

### DIFF
--- a/lts_array/classes/lts_data_class.py
+++ b/lts_array/classes/lts_data_class.py
@@ -46,12 +46,10 @@ class DataBin:
                     latlist.remove(latlist[remove_elements[jj]])
                     lonlist.remove(lonlist[remove_elements[jj]])
                 else:
-                    _x, _y = rij
-                    _x_list = list(_x)
-                    _y_list = list(_y)
-                    _x_list.remove(_x_list[remove_elements[jj]])
-                    _y_list.remove(_y_list[remove_elements[jj]])
-                    rij = np.array([_x_list, _y_list])
+                    _x, _y = [list(_) for _ in rij]
+                    _x.remove(_x[remove_elements[jj]])
+                    _y.remove(_y[remove_elements[jj]])
+                    rij = np.array([_x, _y])
                 remove_elements -= 1
 
         # Save the station name

--- a/lts_array/classes/lts_data_class.py
+++ b/lts_array/classes/lts_data_class.py
@@ -29,8 +29,8 @@ class DataBin:
             lonlist (list): A list of longitude points.
             rij (array or None): A NumPy array with the first row corresponding to
                 cartesian "X" - coordinates and the second row corresponding to
-                cartesian "Y" - coordinates, in units of km. If this is not ``None``
-                then ``latlist`` and ``lonlist`` are ignored.
+                cartesian "Y" - coordinates, in units of km. If this is provided then
+                ``latlist`` and ``lonlist`` are ignored.
             remove_elements (list): A list of elements to remove before processing. Python numbering is used, so "[0]" removes the first element.
         """
         # Check that all traces have the same length

--- a/lts_array/classes/lts_data_class.py
+++ b/lts_array/classes/lts_data_class.py
@@ -17,7 +17,7 @@ class DataBin:
         self.window_overlap = window_overlap
         self.alpha = alpha
 
-    def build_data_arrays(self, st, latlist, lonlist, rij=None, remove_elements=None):
+    def build_data_arrays(self, st, latlist, lonlist, remove_elements=None, rij=None):
         """ Collect basic data from stream file. Project lat/lon into r_ij coordinates.
 
         Alternatively, if ``rij`` is provided, ``latlist`` and ``lonlist`` are not used
@@ -27,11 +27,11 @@ class DataBin:
             st (stream): An obspy stream object.
             latlist (list): A list of latitude points.
             lonlist (list): A list of longitude points.
+            remove_elements (list): A list of elements to remove before processing. Python numbering is used, so "[0]" removes the first element.
             rij (array or None): A NumPy array with the first row corresponding to
                 cartesian "X" - coordinates and the second row corresponding to
                 cartesian "Y" - coordinates, in units of km. If this is provided then
                 ``latlist`` and ``lonlist`` are ignored.
-            remove_elements (list): A list of elements to remove before processing. Python numbering is used, so "[0]" removes the first element.
         """
         # Check that all traces have the same length
         if len(set([len(tr) for tr in st])) != 1:

--- a/lts_array/classes/lts_data_class.py
+++ b/lts_array/classes/lts_data_class.py
@@ -17,13 +17,20 @@ class DataBin:
         self.window_overlap = window_overlap
         self.alpha = alpha
 
-    def build_data_arrays(self, st, latlist, lonlist, remove_elements=None):
+    def build_data_arrays(self, st, latlist, lonlist, rij=None, remove_elements=None):
         """ Collect basic data from stream file. Project lat/lon into r_ij coordinates.
+
+        Alternatively, if ``rij`` is provided, ``latlist`` and ``lonlist`` are not used
+        and the provided Cartesion coordinates ``rij`` are used instead.
 
         Args:
             st (stream): An obspy stream object.
             latlist (list): A list of latitude points.
             lonlist (list): A list of longitude points.
+            rij (array or None): A NumPy array with the first row corresponding to
+                cartesian "X" - coordinates and the second row corresponding to
+                cartesian "Y" - coordinates, in units of km. If this is not ``None``
+                then ``latlist`` and ``lonlist`` are ignored.
             remove_elements (list): A list of elements to remove before processing. Python numbering is used, so "[0]" removes the first element.
         """
         # Check that all traces have the same length
@@ -35,8 +42,16 @@ class DataBin:
             remove_elements = np.sort(remove_elements)
             for jj in range(0, len(remove_elements)):
                 st.remove(st[remove_elements[jj]])
-                latlist.remove(latlist[remove_elements[jj]])
-                lonlist.remove(lonlist[remove_elements[jj]])
+                if rij is None:
+                    latlist.remove(latlist[remove_elements[jj]])
+                    lonlist.remove(lonlist[remove_elements[jj]])
+                else:
+                    _x, _y = rij
+                    _x_list = list(_x)
+                    _y_list = list(_y)
+                    _x_list.remove(_x_list[remove_elements[jj]])
+                    _y_list.remove(_y_list[remove_elements[jj]])
+                    rij = np.array([_x_list, _y_list])
                 remove_elements -= 1
 
         # Save the station name
@@ -69,7 +84,10 @@ class DataBin:
         for ii, tr in enumerate(st):
             self.data[:, ii] = tr.data
         # Set the array coordinates
-        self.rij = self.getrij(latlist, lonlist)
+        if rij is None:
+            self.rij = self.getrij(latlist, lonlist)
+        else:
+            self.rij = rij
         # Make sure the least squares problem is well-posed
         # rij must have at least 3 elements
         if np.shape(self.rij)[1] < 3:
@@ -92,10 +110,9 @@ class DataBin:
 
         Returns:
             (array):
-            ``rij``: A numpy array with the first row corresponding to
+            ``rij``: A NumPy array with the first row corresponding to
             cartesian "X" - coordinates and the second row
-            corresponding to cartesian "Y" - coordinates.
-
+            corresponding to cartesian "Y" - coordinates, in units of km.
         """
 
         # Check that the lat-lon arrays are the same size.

--- a/lts_array/classes/lts_data_class.py
+++ b/lts_array/classes/lts_data_class.py
@@ -85,6 +85,7 @@ class DataBin:
         if rij is None:
             self.rij = self.getrij(latlist, lonlist)
         else:
+            print('Ignoring `lat_list` and `lon_list` since `rij` array was provided!')
             self.rij = rij
         # Make sure the least squares problem is well-posed
         # rij must have at least 3 elements

--- a/lts_array/ltsva.py
+++ b/lts_array/ltsva.py
@@ -40,7 +40,7 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot
 
     # Build data object
     data = DataBin(window_length, window_overlap, alpha)
-    data.build_data_arrays(st, lat_list, lon_list, rij, remove_elements)
+    data.build_data_arrays(st, lat_list, lon_list, remove_elements, rij)
 
     # Plot array coordinates as a check
     if plot_array_coordinates:

--- a/lts_array/ltsva.py
+++ b/lts_array/ltsva.py
@@ -6,7 +6,7 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
-def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot_array_coordinates=False, remove_elements=None):
+def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, rij=None, plot_array_coordinates=False, remove_elements=None):
     r""" Process infrasound or seismic array data with least trimmed squares (LTS).
 
     Args:
@@ -17,6 +17,10 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot
         window_overlap (float): Window overlap in the range (0.0 - 1.0).
         alpha (float): Fraction of data for LTS subsetting [0.5 - 1.0].
             Choose 1.0 for ordinary least squares (default).
+        rij (array or None): A NumPy array with the first row corresponding to cartesian
+            "X" - coordinates and the second row corresponding to cartesian "Y" -
+            coordinates, in units of km. If this is not ``None`` then ``lat_list`` and
+            ``lon_list`` are ignored.
         plot_array_coordinates (bool): Plot array coordinates? Defaults to False.
         remove_elements (list): (Optional) Remove element number(s) from ``st``, ``lat_list``, and ``lon_list`` before processing. Here numbering refers to the Python index (e.g. [0] = remove 1st element in stream).
 
@@ -36,7 +40,7 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot
 
     # Build data object
     data = DataBin(window_length, window_overlap, alpha)
-    data.build_data_arrays(st, lat_list, lon_list, remove_elements)
+    data.build_data_arrays(st, lat_list, lon_list, rij, remove_elements)
 
     # Plot array coordinates as a check
     if plot_array_coordinates:

--- a/lts_array/ltsva.py
+++ b/lts_array/ltsva.py
@@ -19,7 +19,7 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, rij=
             Choose 1.0 for ordinary least squares (default).
         rij (array or None): A NumPy array with the first row corresponding to cartesian
             "X" - coordinates and the second row corresponding to cartesian "Y" -
-            coordinates, in units of km. If this is not ``None`` then ``lat_list`` and
+            coordinates, in units of km. If this is provided then ``lat_list`` and
             ``lon_list`` are ignored.
         plot_array_coordinates (bool): Plot array coordinates? Defaults to False.
         remove_elements (list): (Optional) Remove element number(s) from ``st``, ``lat_list``, and ``lon_list`` before processing. Here numbering refers to the Python index (e.g. [0] = remove 1st element in stream).

--- a/lts_array/ltsva.py
+++ b/lts_array/ltsva.py
@@ -6,7 +6,7 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
-def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, rij=None, plot_array_coordinates=False, remove_elements=None):
+def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot_array_coordinates=False, remove_elements=None, rij=None):
     r""" Process infrasound or seismic array data with least trimmed squares (LTS).
 
     Args:
@@ -17,12 +17,12 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, rij=
         window_overlap (float): Window overlap in the range (0.0 - 1.0).
         alpha (float): Fraction of data for LTS subsetting [0.5 - 1.0].
             Choose 1.0 for ordinary least squares (default).
+        plot_array_coordinates (bool): Plot array coordinates? Defaults to False.
+        remove_elements (list): (Optional) Remove element number(s) from ``st``, ``lat_list``, and ``lon_list`` before processing. Here numbering refers to the Python index (e.g. [0] = remove 1st element in stream).
         rij (array or None): A NumPy array with the first row corresponding to cartesian
             "X" - coordinates and the second row corresponding to cartesian "Y" -
             coordinates, in units of km. If this is provided then ``lat_list`` and
             ``lon_list`` are ignored.
-        plot_array_coordinates (bool): Plot array coordinates? Defaults to False.
-        remove_elements (list): (Optional) Remove element number(s) from ``st``, ``lat_list``, and ``lon_list`` before processing. Here numbering refers to the Python index (e.g. [0] = remove 1st element in stream).
 
     Returns:
         (tuple):


### PR DESCRIPTION
This PR adds an `rij` argument to the `ltsva()` function. If `rij` is provided (i.e., it's not `None`) then the input `lat_list` and `lon_list` are ignored and `ltsva()` directly uses the provided `rij` Cartesian array.

The motivation is that we might not always have array coordinates in terms of latitude and longitude. E.g. this summer we are deploying an array that will likely be measured using compass bearings and measuring tape — I'll create an `rij` array for that. Other use cases include synthetic modeling, etc.

I tested `example.py` with `rij` being `None` versus an array, and I tried providing a list to `remove_elements` — everything worked for me.