### PR TITLE
Update mdccm with dropped stations

### DIFF
--- a/lts_array/ltsva.py
+++ b/lts_array/ltsva.py
@@ -33,8 +33,8 @@ def ltsva(st, lat_list, lon_list, window_length, window_overlap, alpha=1.0, plot
             ``mdccm`` (array): An array of median cross-correlation maxima.
             ``stdict`` (dict): A dictionary of flagged element pairs.
             ``sigma_tau`` (array): An array of sigma_tau values.
-            ``conf_int_vel`` (array): An array of 95% confidence intervals for the trace velocity.
-            ``conf_int_baz`` (array): An array of 95% confidence intervals for the back-azimuth.
+            ``conf_int_vel`` (array): An array of 90% confidence intervals for the trace velocity.
+            ``conf_int_baz`` (array): An array of 90% confidence intervals for the back-azimuth.
 
     """
 


### PR DESCRIPTION
Fix mdccm calculation for LTS so it reflects which pairs were kept and dropped. Save max cross-corr values through time, then use element_weights to drop the correct station pairs and update mdccm. 
Also update description of ltsva function to say 90% confidence intervals.