### PR TITLE
Remove spike detection

### DIFF
--- a/lts_array/classes/lts_classes.py
+++ b/lts_array/classes/lts_classes.py
@@ -61,11 +61,6 @@ def fast_LTS(nits, tau, time_delay_mad, xij_standardized, xij_mad, dimension_num
     """
     for jj in range(nits):
 
-        # Check for data spike.
-        if (time_delay_mad[jj] == 0) or (np.count_nonzero(tau[:, jj, :]) < (co_array_num - 2)):
-            # We have a data spike, so do not process.
-            continue
-
         # Standardize the y-values
         y_var = tau[:, jj, :] / time_delay_mad[jj]
         X_var = xij_standardized
@@ -659,11 +654,6 @@ def post_process(dimension_number, co_array_num, alpha, h, nits, tau, xij, coeff
 
     for jj in range(0, nits):
 
-        # Check for data spike:
-        if np.count_nonzero(tau[:, jj, :]) < (co_array_num - 2):
-            # We have a data spike, so do not process.
-            continue
-
         # Now use original arrays
         y_var = tau[:, jj, :]
 
@@ -722,10 +712,12 @@ def post_process(dimension_number, co_array_num, alpha, h, nits, tau, xij, coeff
         # Calculate the sigma_tau value (Szuberla et al. 2006).
         residuals = tau[weights, jj, :] - (xij[weights, :] @ z_final)
         m_w, _ = np.shape(xij[weights, :])
-        with np.errstate(invalid='raise'):
+
+        with np.errstate(invalid="raise"):
             try:
-                sigma_tau[jj] = np.sqrt(tau[weights, jj, :].T @ residuals / (
-                    m_w - dimension_number))[0]
+                sigma_tau_value = tau[weights, jj, :].T @ residuals
+                sigma_tau_value = sigma_tau_value / (m_w - dimension_number)
+                sigma_tau[jj] = np.sqrt(float(np.asarray(sigma_tau_value).squeeze()))
             except FloatingPointError:
                 pass
 
@@ -755,8 +747,8 @@ def post_process(dimension_number, co_array_num, alpha, h, nits, tau, xij, coeff
         # Halving here s.t. +/- value expresses uncertainty bounds.
         # Remove the 1/2's to get full values to express
         # coverage ellipse area.
-        conf_int_baz[jj] = 0.5 * sig_theta
-        conf_int_vel[jj] = 0.5 * np.abs(np.diff(1 / eExtrm[:2]))
+        conf_int_baz[jj] = 0.5 * float(np.asarray(sig_theta).squeeze())
+        conf_int_vel[jj] = 0.5 * float(np.asarray(np.abs(np.diff(1 / eExtrm[:2]))).squeeze())
 
         # Cast weights to int for output
         element_weights[:, jj] = weights * 1
@@ -907,11 +899,6 @@ class OLSEstimator(LsBeam):
         # Loop through time
         for jj in range(data.nits):
 
-            # Check for data spike.
-            if (self.time_delay_mad[jj] == 0) or (np.count_nonzero(self.tau[:, jj, :]) < (self.co_array_num - 2)):
-                # We have a data spike, so do not process.
-                continue
-
             y_var = self.tau[:, jj, :] / self.time_delay_mad[jj]
             qt = self.q_xij.conj().T @ y_var
             z_final = lstsq(self.r_xij, qt)[0]
@@ -932,8 +919,13 @@ class OLSEstimator(LsBeam):
 
             # Calculate the sigma_tau value (Szuberla et al. 2006).
             residuals = self.tau[:, jj, :] - (self.xij @ z_final)
-            self.sigma_tau[jj] = np.sqrt(self.tau[:, jj, :].T @ residuals / (
-                self.co_array_num - self.dimension_number))[0]
+
+            sigma_tau_value = self.tau[:, jj, :].T @ residuals
+            sigma_tau_value = sigma_tau_value / (
+                    self.co_array_num - self.dimension_number
+            )
+
+            self.sigma_tau[jj] = np.sqrt(float(np.asarray(sigma_tau_value).squeeze()))
 
             # Calculate uncertainties from Szuberla & Olson, 2004
             # Equation 16
@@ -960,8 +952,8 @@ class OLSEstimator(LsBeam):
                 # Halving here s.t. +/- value expresses uncertainty bounds.
                 # Remove the 1/2's to get full values to express
                 # coverage ellipse area.
-                self.conf_int_baz[jj] = 0.5 * sig_theta
-                self.conf_int_vel[jj] = 0.5 * np.abs(np.diff(1 / eExtrm[:2]))
+                self.conf_int_baz[jj] = 0.5 * float(np.asarray(sig_theta).squeeze())
+                self.conf_int_vel[jj] = 0.5 * float(np.asarray(np.abs(np.diff(1 / eExtrm[:2]))).squeeze())
 
             except ValueError:
                 self.conf_int_baz[jj] = np.nan


### PR DESCRIPTION
This PR removes the "spike detection" that I think was initially for data glitches/spikes that are rare. This was instead causing some issues with seismic data where the arrivals traverse the array much more quickly and were not getting processed. Addresses #33. Sorry for the delay!